### PR TITLE
Fix switch avg

### DIFF
--- a/cores/averager_counter_v1_0/averager_counter.v
+++ b/cores/averager_counter_v1_0/averager_counter.v
@@ -25,7 +25,7 @@ module averager_counter #
   reg [FAST_COUNT_WIDTH-1:0] fast_count;
   reg [SLOW_COUNT_WIDTH-1:0] slow_count;
   reg [SLOW_COUNT_WIDTH-1:0] n_avg;
-  reg avg_on_out_reg;
+  reg avg_on_out_reg0, avg_on_out_reg1;
 
   initial begin
     init_restart <= 0;
@@ -55,7 +55,8 @@ module averager_counter #
   always @(posedge clk) begin
     if ((wen) && (fast_count == (count_max_reg - 2))) begin
       clr_fback <= ~avg_on;
-      avg_on_out_reg <= avg_on;
+      avg_on_out_reg0 <= avg_on;
+      avg_on_out_reg1 <= avg_on_out_reg0;
     end
   end
 
@@ -70,7 +71,7 @@ module averager_counter #
           wen <= 0;
           slow_count <= 0;
           n_avg <= slow_count + 1;
-          avg_on_out <= avg_on_out_reg;
+          avg_on_out <= avg_on_out_reg1;
         end else begin
           slow_count <= slow_count + 1;
           if (init_restart) begin

--- a/cores/averager_counter_v1_0/averager_counter.v
+++ b/cores/averager_counter_v1_0/averager_counter.v
@@ -10,10 +10,12 @@ module averager_counter #
   input  wire                         clken,
   input  wire [FAST_COUNT_WIDTH-1:0]  count_max,
   input  wire                         clk,
-  output reg                          init,
+  input  wire                         avg_on,
   output reg                          ready,
   output reg                          wen,
   output reg  [SLOW_COUNT_WIDTH-1:0]  n_avg,
+  output reg                          clr_fback,
+  output reg                          avg_on_out,
   output wire [FAST_COUNT_WIDTH+1:0]  address
 );
 
@@ -23,6 +25,7 @@ module averager_counter #
   reg [FAST_COUNT_WIDTH-1:0] fast_count;
   reg [SLOW_COUNT_WIDTH-1:0] slow_count;
   reg [SLOW_COUNT_WIDTH-1:0] n_avg;
+  reg avg_on_out_reg;
 
   initial begin
     init_restart <= 0;
@@ -45,15 +48,14 @@ module averager_counter #
         if (init_restart) begin
           init_restart <= 0;
         end
-      end    
+      end
     end
   end
 
   always @(posedge clk) begin
     if ((wen) && (fast_count == (count_max_reg - 2))) begin
-      init <= 1;
-    end else begin
-      init <= 0;
+      clr_fback <= ~avg_on;
+      avg_on_out_reg <= avg_on;
     end
   end
 
@@ -68,6 +70,7 @@ module averager_counter #
           wen <= 0;
           slow_count <= 0;
           n_avg <= slow_count + 1;
+          avg_on_out <= avg_on_out_reg;
         end else begin
           slow_count <= slow_count + 1;
           if (init_restart) begin

--- a/cores/averager_counter_v1_0/averager_counter_tb.v
+++ b/cores/averager_counter_v1_0/averager_counter_tb.v
@@ -9,9 +9,11 @@ module averager_counter_tb();
   reg                          clken;
   reg [FAST_COUNT_WIDTH-1:0]   count_max;
   reg                          clk;
-  wire                         init;
+  reg                          avg_on;
+  wire                         clr_fback;
   wire                         ready;
   wire                         wen;
+  wire                         avg_on_out;
   wire [SLOW_COUNT_WIDTH-1:0]  n_avg;
   wire [FAST_COUNT_WIDTH+1:0]  address;
 
@@ -22,10 +24,12 @@ module averager_counter_tb();
     .clken(clken),
     .count_max(count_max),
     .clk(clk),
-    .init(init),
+    .avg_on(avg_on),
+    .clr_fback(clr_fback),
     .ready(ready),
     .wen(wen),
     .n_avg(n_avg),
+    .avg_on_out(avg_on_out),
     .address(address)
   );
 
@@ -36,10 +40,14 @@ module averager_counter_tb();
     restart = 0;
     clken = 0;
     count_max = 15;
+    avg_on = 1;
     #(10*CLK_PERIOD) clken = 1;
     #(40 *CLK_PERIOD) restart = 1;
     #(1*CLK_PERIOD) restart = 0;
-    #(100*CLK_PERIOD)
+    #(100*CLK_PERIOD) avg_on = 0;
+    #(500*CLK_PERIOD) restart = 1;
+    #(1*CLK_PERIOD) restart = 0;
+    #(1000*CLK_PERIOD) 
     $finish;
   end
   

--- a/drivers/oscillo/oscillo.hpp
+++ b/drivers/oscillo/oscillo.hpp
@@ -34,7 +34,7 @@ class Oscillo
 
     std::vector<float>& read_all_channels_decim(uint32_t decim_factor, uint32_t index_low, uint32_t index_high);
 
-    void set_averaging(bool avg_status);
+    void set_averaging(bool avg_on);
     
     uint32_t get_num_average();
 
@@ -51,7 +51,6 @@ class Oscillo
     Klib::DevMem& dev_mem;
 
     int status;
-    bool avg_on; // True if averaging is enabled
 
     uint32_t *raw_data_1 = nullptr;
     uint32_t *raw_data_2 = nullptr;

--- a/drivers/spectrum/spectrum.cpp
+++ b/drivers/spectrum/spectrum.cpp
@@ -110,6 +110,8 @@ std::array<float, WFM_SIZE>& Spectrum::get_spectrum()
 {
     Klib::SetBit(dev_mem.GetBaseAddr(config_map) + ADDR_OFF, 1);    
     _wait_for_acquisition();
+    uint32_t avg_on = bool(Klib::ReadReg32(dev_mem.GetBaseAddr(status_map)+AVG_ON_OUT_OFF));
+
     if (avg_on) {
         float num_avg = float(get_num_average());
         for(unsigned int i=0; i<WFM_SIZE; i++)
@@ -134,6 +136,7 @@ std::vector<float>& Spectrum::get_spectrum_decim(uint32_t decim_factor, uint32_t
     uint32_t n_pts = (index_high - index_low)/decim_factor;
     spectrum_decim.resize(n_pts);
     _wait_for_acquisition();
+    uint32_t avg_on = bool(Klib::ReadReg32(dev_mem.GetBaseAddr(status_map)+AVG_ON_OUT_OFF));
 
     if (avg_on) {
         float num_avg = float(get_num_average());
@@ -149,14 +152,12 @@ std::vector<float>& Spectrum::get_spectrum_decim(uint32_t decim_factor, uint32_t
     return spectrum_decim;
 }
 
-void Spectrum::set_averaging(bool avg_status)
+void Spectrum::set_averaging(bool avg_on)
 {
-    avg_on = avg_status;
-    
     if(avg_on)
-        Klib::ClearBit(dev_mem.GetBaseAddr(config_map) + AVG_OFF_OFF, 0);
+        Klib::SetBit(dev_mem.GetBaseAddr(config_map) + AVG_ON_OFF, 0);
     else
-        Klib::SetBit(dev_mem.GetBaseAddr(config_map) + AVG_OFF_OFF, 0);
+        Klib::ClearBit(dev_mem.GetBaseAddr(config_map) + AVG_ON_OFF, 0);
 }
 
 uint32_t Spectrum::get_num_average()

--- a/drivers/spectrum/spectrum.hpp
+++ b/drivers/spectrum/spectrum.hpp
@@ -70,8 +70,6 @@ class Spectrum
     Klib::DevMem& dev_mem;
     int status;
 
-    bool avg_on; // True if averaging is enabled
-
     // Memory maps IDs:
     Klib::MemMapID config_map;
     Klib::MemMapID status_map;

--- a/projects/averager_test/block_design.tcl
+++ b/projects/averager_test/block_design.tcl
@@ -11,8 +11,8 @@ set slow_count_width [expr 32 - $config::bram_addr_width]
 create_bd_port -dir I -type clk clk
 connect_bd_net [get_bd_pins /$module/clk] [get_bd_ports clk]
 
-create_bd_port -dir I avg_off
-connect_bd_net [get_bd_pins /$module/avg_off] [get_bd_ports avg_off]
+create_bd_port -dir I avg_on
+connect_bd_net [get_bd_pins /$module/avg_on] [get_bd_ports avg_on]
 
 create_bd_port -dir I -from [expr $config::adc_width - 1] -to 0 din
 connect_bd_net [get_bd_pins /$module/din] [get_bd_ports din]
@@ -44,3 +44,5 @@ connect_bd_net [get_bd_pins /$module/dout] [get_bd_ports dout]
 create_bd_port -dir O ready
 connect_bd_net [get_bd_pins /$module/ready] [get_bd_ports ready]
 
+create_bd_port -dir O avg_on_out
+connect_bd_net [get_bd_pins /$module/avg_on_out] [get_bd_ports avg_on_out]

--- a/projects/averager_test/test_bench.v
+++ b/projects/averager_test/test_bench.v
@@ -4,7 +4,7 @@ module averager_tb();
 
   parameter WIDTH = 8;
   
-  reg avg_off;
+  reg avg_on;
   reg clk;
   reg [13:0]din;
   reg [WIDTH-1:0]period;
@@ -16,12 +16,13 @@ module averager_tb();
   wire [31:0]dout;
   wire [32-WIDTH-1:0] n_avg;
   wire ready;
+  wire avg_on_out;
   wire [WIDTH+1:0]addr;
 
   system_wrapper
   DUT (
     .addr(addr),
-    .avg_off(avg_off),
+    .avg_on(avg_on),
     .clk(clk),
     .din(din),
     .dout(dout),
@@ -31,14 +32,15 @@ module averager_tb();
     .restart(restart),
     .threshold(threshold),
     .tvalid(tvalid),
-    .wen(wen)  
+    .wen(wen),
+    .avg_on_out(avg_on_out) 
   );
 
   parameter CLK_PERIOD = 8;
 
   initial begin
     clk = 0;
-    avg_off = 0;
+    avg_on = 0;
     din = 0;
     restart = 0;
     tvalid = 0;
@@ -51,11 +53,11 @@ module averager_tb();
 
     #(50*CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;
-    #(10 * CLK_PERIOD) avg_off = 1;
+    #(10 * CLK_PERIOD) avg_on = 0;
  
     #(2000 * CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;
-    #(10 * CLK_PERIOD) avg_off = 0;
+    #(10 * CLK_PERIOD) avg_on = 0;
 
     #(2000 * CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;

--- a/projects/averager_test/test_bench.v
+++ b/projects/averager_test/test_bench.v
@@ -40,7 +40,7 @@ module averager_tb();
 
   initial begin
     clk = 0;
-    avg_on = 0;
+    avg_on = 1;
     din = 0;
     restart = 0;
     tvalid = 0;
@@ -53,16 +53,20 @@ module averager_tb();
 
     #(50*CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;
-    #(10 * CLK_PERIOD) avg_on = 0;
+    #(10 * CLK_PERIOD) avg_on = 1;
  
     #(2000 * CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;
+    #(10 * CLK_PERIOD) avg_on = 1;
+
+    #(2000 * CLK_PERIOD) restart = 1;
+    #(CLK_PERIOD) restart = 0;
     #(10 * CLK_PERIOD) avg_on = 0;
 
     #(2000 * CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;
 
-    #(2000 * CLK_PERIOD) restart = 1;
+    #(1000 * CLK_PERIOD) restart = 1;
     #(CLK_PERIOD) restart = 0;
 
     #(100000*CLK_PERIOD)

--- a/projects/oscillo/main.yml
+++ b/projects/oscillo/main.yml
@@ -41,6 +41,9 @@ status_offsets:
   - n_avg1
   - avg_ready0
   - avg_ready1
+  - avg_on_out0
+  - avg_on_out1
+
 
 parameters:
   bram_addr_width: 13
@@ -49,7 +52,7 @@ parameters:
   pwm_width: 10
   n_pwm: 4
   config_size: 16
-  status_size: 16
+  status_size: 32
 
 drivers:
   - drivers/device_memory

--- a/projects/oscillo/oscillo.tcl
+++ b/projects/oscillo/oscillo.tcl
@@ -3,6 +3,7 @@ source lib/averager.tcl
 ###########################################################
 # Add ADC BRAMs
 ###########################################################
+
 for {set i 0} {$i < 2} {incr i} {
   set channel [lindex {a b} $i]
   set adc_bram_name adc${i}_bram
@@ -18,7 +19,7 @@ for {set i 0} {$i < 2} {incr i} {
 
   connect_pins $avg_name/clk         $adc_clk
   connect_pins $avg_name/restart     $address_name/restart
-  connect_pins $avg_name/avg_on     $config_name/Out[set config::avg${i}_offset]
+  connect_pins $avg_name/avg_on      $config_name/Out[set config::avg${i}_offset]
   connect_pins $avg_name/period      $config_name/Out[set config::period${i}_offset]
   connect_pins $avg_name/threshold   $config_name/Out[set config::threshold${i}_offset]
   connect_pins $avg_name/tvalid      $address_name/tvalid

--- a/projects/oscillo/oscillo.tcl
+++ b/projects/oscillo/oscillo.tcl
@@ -18,7 +18,7 @@ for {set i 0} {$i < 2} {incr i} {
 
   connect_pins $avg_name/clk         $adc_clk
   connect_pins $avg_name/restart     $address_name/restart
-  connect_pins $avg_name/avg_off     $config_name/Out[set config::avg${i}_offset]
+  connect_pins $avg_name/avg_on     $config_name/Out[set config::avg${i}_offset]
   connect_pins $avg_name/period      $config_name/Out[set config::period${i}_offset]
   connect_pins $avg_name/threshold   $config_name/Out[set config::threshold${i}_offset]
   connect_pins $avg_name/tvalid      $address_name/tvalid
@@ -28,4 +28,5 @@ for {set i 0} {$i < 2} {incr i} {
   connect_pins $avg_name/wen         blk_mem_gen_$adc_bram_name/web
   connect_pins $avg_name/n_avg       sts/In[set config::n_avg${i}_offset]
   connect_pins $avg_name/ready       sts/In[set config::avg_ready${i}_offset]
+  connect_pins $avg_name/avg_on_out  sts/In[set config::avg_on_out${i}_offset]
 }

--- a/projects/spectrum/main.yml
+++ b/projects/spectrum/main.yml
@@ -36,7 +36,7 @@ config_offsets:
   - addr
   - substract_mean
   - cfg_fft
-  - avg_off
+  - avg_on
   - peak_address_low
   - peak_address_high
   - peak_address_reset
@@ -49,6 +49,7 @@ status_offsets:
   - peak_address
   - peak_maximum
   - avg_ready
+  - avg_on_out
 
 parameters:
   bram_addr_width: 12

--- a/projects/spectrum/spectrum.tcl
+++ b/projects/spectrum/spectrum.tcl
@@ -60,7 +60,7 @@ add_averager_module $avg_name $config::bram_addr_width
 
 connect_pins $avg_name/clk         $adc_clk
 connect_pins $avg_name/restart     $address_name/restart
-connect_pins $avg_name/avg_off     $config_name/Out$config::avg_off_offset
+connect_pins $avg_name/avg_on     $config_name/Out$config::avg_on_offset
 connect_pins $avg_name/period      $config_name/Out$config::period0_offset
 connect_pins $avg_name/threshold   $config_name/Out$config::threshold0_offset
 
@@ -73,6 +73,7 @@ connect_pins $avg_name/wen         blk_mem_gen_$spectrum_bram_name/web
 
 connect_pins $avg_name/n_avg      $status_name/In$config::n_avg_offset
 connect_pins $avg_name/ready      $status_name/In$config::avg_ready_offset
+connect_pins $avg_name/avg_on_out sts/In$config::avg_on_out_offset
 
 # Add peak detector
 


### PR DESCRIPTION
The averaging status (ON or OFF) is now read on the PL and not guessed from what has been set on the PS side.

The signal does no longer jump when switching between ON and OFF.