### PR TITLE
Update averager

### DIFF
--- a/drivers/oscillo/oscillo.cpp
+++ b/drivers/oscillo/oscillo.cpp
@@ -19,6 +19,10 @@ Oscillo::Oscillo(Klib::DevMem& dvm_)
     raw_data[1] = dvm.read_buffer<int32_t>(adc_map[1]);
 
     set_averaging(false); // Reset averaging
+
+    // set tvalid delay to 19 * 8 ns
+    dvm.write32(config_map, ADDR_OFF, 19 << 2);
+    
     set_period(WFM_SIZE);
     set_n_avg_min(0);
 }

--- a/drivers/oscillo/oscillo.hpp
+++ b/drivers/oscillo/oscillo.hpp
@@ -21,7 +21,7 @@ class Oscillo
     int Open() {return dvm.is_ok() ? 0 : -1;}
 
     void reset() {
-        dvm.clear_bit(config_map, ADDR_OFF, 1);
+        dvm.clear_bit(config_map, ADDR_OFF, 0);
         dvm.set_bit(config_map, ADDR_OFF, 0);
     }
 

--- a/drivers/spectrum/spectrum.cpp
+++ b/drivers/spectrum/spectrum.cpp
@@ -23,6 +23,10 @@ Spectrum::Spectrum(Klib::DevMem& dvm_)
     fifo.set_map(peak_fifo_map);
 
     set_averaging(true);
+
+    // set tvalid delay to 19 * 8 ns
+    dvm.write32(config_map, ADDR_OFF, 19 << 2);
+
     set_address_range(0, WFM_SIZE);
     set_period(WFM_SIZE);
     set_n_avg_min(0);

--- a/drivers/spectrum/spectrum.hpp
+++ b/drivers/spectrum/spectrum.hpp
@@ -31,7 +31,7 @@ class Spectrum
     }
 
     void reset() {
-        dvm.clear_bit(config_map, ADDR_OFF, 1);
+        dvm.clear_bit(config_map, ADDR_OFF, 0);
         dvm.set_bit(config_map, ADDR_OFF, 0);
     }
 

--- a/fpga/cores/address_generator_v1_0/address_generator.v
+++ b/fpga/cores/address_generator_v1_0/address_generator.v
@@ -23,7 +23,6 @@ module address_generator #
         count <= count + 1;
       end else begin
         count <= 0;
-        count_max_reg <= count_max;
       end
     end
   end

--- a/fpga/cores/address_generator_v1_0/address_generator.v
+++ b/fpga/cores/address_generator_v1_0/address_generator.v
@@ -19,7 +19,7 @@ module address_generator #
       count <= 0;
       count_max_reg <= count_max;
     end else begin
-      if (count != count_max) begin
+      if (count != count_max_reg) begin
         count <= count + 1;
       end else begin
         count <= 0;

--- a/fpga/cores/averager_counter_v1_0/averager_counter.v
+++ b/fpga/cores/averager_counter_v1_0/averager_counter.v
@@ -40,7 +40,7 @@ module averager_counter #
   always @(posedge clk) begin
     if (srst) begin
       init_restart <= 0;
-      ready <= 1;      
+      ready <= 1;
     end else begin
       if (restart && clken_reg) begin
         init_restart <= 1;
@@ -67,6 +67,7 @@ module averager_counter #
 
   always @(posedge clk) begin
     if (srst) begin
+      count_max_reg <= count_max;
       fast_count <= 0;
       slow_count <= 0;
       n_avg <= 0;
@@ -77,7 +78,6 @@ module averager_counter #
         if (fast_count == count_max_reg) begin
           fast_count <= 0;
           if (wen) begin
-            count_max_reg <= count_max;
             wen <= 0;
             slow_count <= 0;
             n_avg <= slow_count + 1;

--- a/fpga/cores/edge_detector_v1_0/edge_detector.v
+++ b/fpga/cores/edge_detector_v1_0/edge_detector.v
@@ -2,6 +2,7 @@
 
 module edge_detector #
 (
+  parameter integer PULSE_WIDTH = 1
 )
 (
   input  wire din,
@@ -12,7 +13,39 @@ module edge_detector #
   always @(posedge clk) begin
     din_next <= din;
   end
-  assign dout = !din_next && din; 
+
+  generate
+    if (PULSE_WIDTH == 1)
+    begin : ONE
+      assign dout = !din_next && din;
+    end
+    if (PULSE_WIDTH > 1)
+    begin : MORE_THAN_ONE
+
+      function integer clogb2 (input integer value);
+        for(clogb2 = 0; value > 0; clogb2 = clogb2 + 1) value = value >> 1;
+      endfunction
+ 
+      localparam integer CNT_WIDTH = clogb2(PULSE_WIDTH);    
+ 
+      reg [CNT_WIDTH-1:0] cnt;
+      reg counting;
+      always @(posedge clk) begin
+        if (!din_next && din) begin
+          cnt <= cnt + 1;
+          counting <= 1;
+        end else begin
+          if (counting && cnt < PULSE_WIDTH) begin
+            cnt <= cnt + 1;
+          end else begin
+            counting <= 0;
+            cnt <= 0;
+          end   
+        end
+      end
+      assign dout = (counting || (!din_next && din));
+    end
+  endgenerate
 
 endmodule
 

--- a/fpga/cores/edge_detector_v1_0/edge_detector_tb.v
+++ b/fpga/cores/edge_detector_v1_0/edge_detector_tb.v
@@ -1,0 +1,31 @@
+`timescale 1 ns / 1 ps
+
+module edge_detector_tb();
+  
+  parameter PULSE_WIDTH = 2;
+
+  reg                          din;
+  reg                          clk;
+  wire                         dout;
+
+  edge_detector #(.PULSE_WIDTH(PULSE_WIDTH)) 
+  DUT (
+    .din(din),
+    .clk(clk),
+    .dout(dout)
+  );
+
+  parameter CLK_PERIOD = 8;
+
+  initial begin
+    clk = 1;
+    din = 0;
+    #(10*CLK_PERIOD) din = 1;
+    #(10*CLK_PERIOD) din = 0;
+    #(40 *CLK_PERIOD) din = 1;
+    $finish;
+  end
+  
+  always #(CLK_PERIOD/2) clk = ~clk;
+
+endmodule

--- a/fpga/tcl/utilities.tcl
+++ b/fpga/tcl/utilities.tcl
@@ -13,7 +13,86 @@ proc sts_pin {name} {
   return $::status_name/In[set config::${name}_offset]
 }
 
+proc get_not_pin {pin_name} {
+  # TODO use function here ...
+  set i 0
+  while 1 {
+    set not_name not_[lindex [split $pin_name /] end]_${i}
+    if {[get_bd_cells $not_name] eq ""} {break}
+    incr i
+  }
+  cell xilinx.com:ip:util_vector_logic:2.0 $not_name {
+    C_SIZE 1
+    C_OPERATION not
+  } {
+    Op1 $pin_name
+  }
+  return $not_name/Res
+}
+
+proc get_Q_pin {in_pin_name {width 1} {depth 1} {ce_pin_name "ce_false"}} {
+  # TODO ... and here
+  set i 0
+  while 1 {
+    set shift_reg_name Q_d${depth}_[lindex [split $in_pin_name /] end]_${i}
+    if {[get_bd_cells $shift_reg_name] eq ""} {break}
+    incr i
+  }
+  if { [string match "ce_false" $ce_pin_name] } {
+    cell xilinx.com:ip:c_shift_ram:12.0 $shift_reg_name {
+      Width.VALUE_SRC USER
+      Width $width
+      Depth $depth
+    } {
+      CLK clk
+      D   $in_pin_name
+    }
+  } else {
+    cell xilinx.com:ip:c_shift_ram:12.0 $shift_reg_name {
+      Width.VALUE_SRC USER
+      Width $width
+      Depth $depth
+      CE true
+    } {
+      CLK clk
+      D   $in_pin_name
+      CE  $ce_pin_name
+    }
+  }
+  return $shift_reg_name/Q
+}
+
+proc get_D_pin {in_pin_name {depth 1} {ce_pin_name 'ce_false'}} {
+  # TODO ... and here
+  set i 0
+  while 1 {
+    set shift_reg_name D_d${depth}_[lindex [split $out_pin_name /] end]_${i}
+    if {[get_bd_cells $shift_reg_name] eq ""} {break}
+    incr i
+  }
+  if { [string match "ce_false" $input_type] } {
+    cell xilinx.com:ip:c_shift_ram:12.0 $shift_reg_name {
+      Depth $depth
+    } {
+      CLK clk
+      Q   $out_pin_name
+    }
+  } else {
+    cell xilinx.com:ip:c_shift_ram:12.0 $shift_reg_name {
+      Depth $depth
+      CE true
+    } {
+      CLK clk
+      Q   $out_pin_name
+      CE  $ce_pin_name
+    }
+  }
+  return $shift_reg_name/D
+}
+
+
 proc get_constant_pin {value width} {
+  # TODO ... and here
   set i 0
   while 1 {
     set const_name const${i}_v${value}_w${width}
@@ -32,9 +111,12 @@ proc connect_pins {pin1 pin2} {
 }
 
 proc connect_constant {name value width pin} {
-  cell xilinx.com:ip:xlconstant:1.1 $name \
-    [list CONST_VAL $value CONST_WIDTH $width] \
-    [list dout $pin]
+  cell xilinx.com:ip:xlconstant:1.1 $name {
+    CONST_VAL $value
+    CONST_WIDTH $width
+  } { 
+    dout $pin
+  }
 }
 
 # http://wiki.tcl.tk/13920

--- a/fpga/tcl/utilities.tcl
+++ b/fpga/tcl/utilities.tcl
@@ -30,7 +30,40 @@ proc get_not_pin {pin_name} {
   return $not_name/Res
 }
 
-proc get_Q_pin {in_pin_name {width 1} {depth 1} {ce_pin_name "ce_false"}} {
+proc get_slice_pin {pin_name width from to} {
+  # TODO ... and here
+  set i 0
+  while 1 {
+    set slice_name slice_from${from}_to${to}_[lindex [split $pin_name /] end]_${i}
+    if {[get_bd_cells $slice_name] eq ""} {break}
+    incr i
+  }
+  cell xilinx.com:ip:xlslice:1.0 $slice_name {
+    DIN_WIDTH $width
+    DIN_FROM $from
+    DIN_TO $to
+  } {
+    Din $pin_name
+  }
+  return $slice_name/Dout
+}
+
+proc get_edge_detector_pin {pin_name {clk clk}} {
+  # TODO ... and here
+  set i 0
+  while 1 {
+    set edge_det_name edge_detector_[lindex [split $pin_name /] end]_${i}
+    if {[get_bd_cells $edge_det_name] eq ""} {break}
+    incr i
+  }
+  cell koheron:user:edge_detector:1.0 $edge_det_name {} {
+    clk $clk
+    din $pin_name
+  }
+  return $edge_det_name/dout
+}
+
+proc get_Q_pin {in_pin_name {width 1} {depth 1} {ce_pin_name "ce_false"} {clk clk}} {
   # TODO ... and here
   set i 0
   while 1 {
@@ -44,7 +77,7 @@ proc get_Q_pin {in_pin_name {width 1} {depth 1} {ce_pin_name "ce_false"}} {
       Width $width
       Depth $depth
     } {
-      CLK clk
+      CLK $clk
       D   $in_pin_name
     }
   } else {
@@ -61,35 +94,6 @@ proc get_Q_pin {in_pin_name {width 1} {depth 1} {ce_pin_name "ce_false"}} {
   }
   return $shift_reg_name/Q
 }
-
-proc get_D_pin {in_pin_name {depth 1} {ce_pin_name 'ce_false'}} {
-  # TODO ... and here
-  set i 0
-  while 1 {
-    set shift_reg_name D_d${depth}_[lindex [split $out_pin_name /] end]_${i}
-    if {[get_bd_cells $shift_reg_name] eq ""} {break}
-    incr i
-  }
-  if { [string match "ce_false" $input_type] } {
-    cell xilinx.com:ip:c_shift_ram:12.0 $shift_reg_name {
-      Depth $depth
-    } {
-      CLK clk
-      Q   $out_pin_name
-    }
-  } else {
-    cell xilinx.com:ip:c_shift_ram:12.0 $shift_reg_name {
-      Depth $depth
-      CE true
-    } {
-      CLK clk
-      Q   $out_pin_name
-      CE  $ce_pin_name
-    }
-  }
-  return $shift_reg_name/D
-}
-
 
 proc get_constant_pin {value width} {
   # TODO ... and here

--- a/projects/address_module/address.tcl
+++ b/projects/address_module/address.tcl
@@ -16,8 +16,12 @@ proc create {module_name bram_width {n_periods 1}} {
   current_bd_instance [create_bd_cell -type hier $module_name]
 
   pins create_bd_pin $bram_width $n_periods
+  
+  # Configuration registers
+  set reset_pin [get_slice_pin cfg 32 0 0]
+  set reset_acq_pin [get_slice_pin cfg 32 1 1]
 
-  cell koheron:user:edge_detector:1.0 reset_base_counter {} {clk clk}
+  connect_pin restart [get_edge_detector_pin $reset_acq_pin]
 
   # Add address counter
 
@@ -28,43 +32,23 @@ proc create {module_name bram_width {n_periods 1}} {
       clk clk
       count_max period$i
       address addr$i
-      sclr reset_base_counter/dout
+      sclr [get_not_pin $reset_pin]
     }
   }
 
-  cell koheron:user:edge_detector:1.0 edge_detector {
-  } { 
-    clk clk
-    dout restart
-  }
-
-  # Configuration registers
-
-  cell xilinx.com:ip:xlslice:1.0 reset_base_counter_slice {
-    DIN_WIDTH 32
-    DIN_FROM 0
-    DIN_TO 0
-  } {
-    Din cfg
-    Dout reset_base_counter/din
-  }
-
-  cell xilinx.com:ip:xlslice:1.0 start_slice {
-    DIN_WIDTH 32
-    DIN_FROM 1
-    DIN_TO 1
-  } {
-    Din cfg
-    Dout edge_detector/Din
-  }
+  set clogb2_depth 5
+  set depth [expr 2**$clogb2_depth]
+  set delay_pin [get_slice_pin cfg 32 [expr 2 + $clogb2_depth -1] 2]
 
   cell xilinx.com:ip:c_shift_ram:12.0 delay_tvalid {
-    Depth 1
+    ShiftRegType Variable_Length_Lossless
+    Depth [expr 2**$clogb2_depth]
     Width 1
   } {
-    D reset_base_counter_slice/Dout
+    D $reset_pin
     CLK clk
     Q tvalid
+    A $delay_pin
   }
 
   current_bd_instance $bd

--- a/projects/averager_module/averager.tcl
+++ b/projects/averager_module/averager.tcl
@@ -165,7 +165,7 @@ proc create {module_name bram_addr_width args} {
   } {
     clk clk
     clken wr_en_and_comp/Res
-    count_max [get_Q_pin period $fast_count_width 1 [get_not_pin tvalid]]
+    count_max period
     n_avg n_avg
     avg_on avg_on
     wen shift_reg/SCLR

--- a/projects/oscillo/oscillo.tcl
+++ b/projects/oscillo/oscillo.tcl
@@ -36,6 +36,5 @@ for {set i 0} {$i < 2} {incr i} {
     n_avg       [sts_pin n_avg$i]
     ready       [sts_pin avg_ready$i]
     avg_on_out  [sts_pin avg_on_out$i]
-    srst        [get_constant_pin 0 1]
   }
 }

--- a/projects/spectrum/spectrum.tcl
+++ b/projects/spectrum/spectrum.tcl
@@ -78,7 +78,6 @@ connect_cell $avg_name {
   n_avg       [sts_pin n_avg]
   ready       [sts_pin avg_ready]
   avg_on_out  [sts_pin avg_on_out]
-  srst        [get_constant_pin 0 1]
 }
 
 connect_cell $subtract_name {


### PR DESCRIPTION
* add option to set `PULSE_WIDTH` in edge_detector
* add `get_not_pin`, `get_slice_pin`, `get_edge_detector_pin` and `get_Q_pin` procedures in `utilities.tcl`
* reset fifo in averager
* add possibility to tune the ~19 x 8 ns delay between DAC and ADC
