### PR TITLE
Register array

### DIFF
--- a/drivers/oscillo/oscillo.hpp
+++ b/drivers/oscillo/oscillo.hpp
@@ -87,8 +87,8 @@ class Oscillo
     }
     
     void set_avg_period(uint32_t avg_period) {
-        dvm.write32(config_map, AVG_PERIOD0_OFF, avg_period - 1);
-        dvm.write32(config_map, AVG_THRESHOLD0_OFF, avg_period - 6);
+        dvm.write32(config_map, AVG_PERIOD_OFF, avg_period - 1);
+        dvm.write32(config_map, AVG_THRESHOLD_OFF, avg_period - 6);
         reset();
     }
 

--- a/drivers/spectrum/spectrum.cpp
+++ b/drivers/spectrum/spectrum.cpp
@@ -38,7 +38,7 @@ Spectrum::Spectrum(Klib::DevMem& dvm_)
 void Spectrum::set_n_avg_min(uint32_t n_avg_min)
 {
     uint32_t n_avg_min_ = (n_avg_min < 2) ? 0 : n_avg_min-2;
-    dvm.write32(config_map, N_AVG_MIN0_OFF, n_avg_min_);
+    dvm.write32(config_map, N_AVG_MIN_OFF, n_avg_min_);
 }
 
 std::array<float, WFM_SIZE>& Spectrum::get_spectrum()
@@ -46,7 +46,7 @@ std::array<float, WFM_SIZE>& Spectrum::get_spectrum()
     dvm.set_bit(config_map,ADDR_OFF, 1);
     wait_for_acquisition();
 
-    if (dvm.read32(status_map, AVG_ON_OUT0_OFF)) {
+    if (dvm.read32(status_map, AVG_ON_OUT_OFF)) {
         float num_avg = float(get_num_average());
         for (unsigned int i=0; i<WFM_SIZE; i++)
             spectrum_data[i] = raw_data[i] / num_avg;
@@ -73,7 +73,7 @@ std::vector<float>& Spectrum::get_spectrum_decim(uint32_t decim_factor, uint32_t
     spectrum_decim.resize(n_pts);
     wait_for_acquisition();
 
-    if (dvm.read32(status_map, AVG_ON_OUT0_OFF)) {
+    if (dvm.read32(status_map, AVG_ON_OUT_OFF)) {
         float num_avg = float(get_num_average());
 
         for (unsigned int i=0; i<spectrum_decim.size(); i++)
@@ -90,9 +90,9 @@ std::vector<float>& Spectrum::get_spectrum_decim(uint32_t decim_factor, uint32_t
 void Spectrum::set_averaging(bool avg_on)
 {
     if (avg_on)
-        dvm.set_bit(config_map, AVG0_OFF, 0);
+        dvm.set_bit(config_map, AVG_OFF, 0);
     else
-        dvm.clear_bit(config_map, AVG0_OFF, 0);
+        dvm.clear_bit(config_map, AVG_OFF, 0);
 }
 
 /////////////////////

--- a/drivers/spectrum/spectrum.hpp
+++ b/drivers/spectrum/spectrum.hpp
@@ -41,8 +41,8 @@ class Spectrum
     }
     
     void set_avg_period(uint32_t avg_period) {
-        dvm.write32(config_map, AVG_PERIOD0_OFF, avg_period - 1);
-        dvm.write32(config_map, AVG_THRESHOLD0_OFF, avg_period - 6);
+        dvm.write32(config_map, AVG_PERIOD_OFF, avg_period - 1);
+        dvm.write32(config_map, AVG_THRESHOLD_OFF, avg_period - 6);
     }
 
     void init_dac_brams() {

--- a/projects/blink/main.yml
+++ b/projects/blink/main.yml
@@ -19,12 +19,10 @@ addresses:
 
 config_registers:
   - led
-  - dac1
-  - dac2
+  - dac[2]
 
 status_registers:
-  - adc1
-  - adc2
+  - adc[2]
 
 parameters:
   bram_addr_width: 13

--- a/projects/oscillo/main.yml
+++ b/projects/oscillo/main.yml
@@ -33,22 +33,22 @@ modules:
 config_registers:
   - spi_in
   - led
-  - pwm[4]
+  - pwm[n_pwm]
   - addr
-  - avg[2]
-  - dac_period[2]
+  - avg[n_adc]
+  - dac_period[n_dac]
   - avg_period
   - avg_threshold
-  - n_avg_min[2]
+  - n_avg_min[n_adc]
   - dac_select
   - addr_select
   - clken_mask
 
 status_registers:
   - spi_out
-  - n_avg[2]
-  - avg_ready[2]
-  - avg_on_out[2]
+  - n_avg[n_adc]
+  - avg_ready[n_adc]
+  - avg_on_out[n_adc]
   - counter[2]
 
 parameters:
@@ -59,6 +59,7 @@ parameters:
   n_pwm: 4
   n_dac_bram: 3
   n_dac: 2
+  n_adc: 2
 
 xdc:
   - projects/base/expansion_connector.xdc

--- a/projects/oscillo/main.yml
+++ b/projects/oscillo/main.yml
@@ -33,33 +33,23 @@ modules:
 config_registers:
   - spi_in
   - led
-  - pwm0
-  - pwm1
-  - pwm2
-  - pwm3
+  - pwm[4]
   - addr
-  - avg0
-  - avg1
-  - dac_period0
-  - dac_period1
-  - avg_period0
-  - avg_threshold0
-  - n_avg_min0
-  - n_avg_min1
+  - avg[2]
+  - dac_period[2]
+  - avg_period
+  - avg_threshold
+  - n_avg_min[2]
   - dac_select
   - addr_select
   - clken_mask
 
 status_registers:
   - spi_out
-  - n_avg0
-  - n_avg1
-  - avg_ready0
-  - avg_ready1
-  - avg_on_out0
-  - avg_on_out1
-  - counter0
-  - counter1
+  - n_avg[2]
+  - avg_ready[2]
+  - avg_on_out[2]
+  - counter[2]
 
 parameters:
   bram_addr_width: 13

--- a/projects/oscillo/oscillo.tcl
+++ b/projects/oscillo/oscillo.tcl
@@ -25,8 +25,8 @@ for {set i 0} {$i < 2} {incr i} {
     clk         $adc_clk
     restart     $address_name/restart
     avg_on      [cfg_pin avg$i]
-    period      [cfg_pin avg_period0]
-    threshold   [cfg_pin avg_threshold0]
+    period      [cfg_pin avg_period]
+    threshold   [cfg_pin avg_threshold]
     n_avg_min   [cfg_pin n_avg_min$i]
     tvalid      $address_name/tvalid
     din         adc_dac/adc[expr $i + 1]

--- a/projects/spectrum/main.yml
+++ b/projects/spectrum/main.yml
@@ -41,22 +41,18 @@ modules:
 config_registers:
   - spi_in
   - led
-  - pwm0
-  - pwm1
-  - pwm2
-  - pwm3
+  - pwm[4]
   - addr
   - substract_mean
   - cfg_fft
-  - avg0
-  - dac_period0
-  - dac_period1
+  - avg
+  - dac_period[2]
   - peak_address_low
   - peak_address_high
   - peak_address_reset
-  - avg_period0
-  - avg_threshold0
-  - n_avg_min0
+  - avg_period
+  - avg_threshold
+  - n_avg_min
   - dac_select
   - addr_select
   - clken_mask
@@ -67,9 +63,8 @@ status_registers:
   - peak_address
   - peak_maximum
   - avg_ready
-  - avg_on_out0
-  - counter0
-  - counter1
+  - avg_on_out
+  - counter[2]
 
 parameters:
   bram_addr_width: 12

--- a/projects/spectrum/main.yml
+++ b/projects/spectrum/main.yml
@@ -46,7 +46,7 @@ config_registers:
   - substract_mean
   - cfg_fft
   - avg
-  - dac_period[2]
+  - dac_period[n_dac]
   - peak_address_low
   - peak_address_high
   - peak_address_reset

--- a/projects/spectrum/spectrum.tcl
+++ b/projects/spectrum/spectrum.tcl
@@ -60,16 +60,16 @@ averager::create $avg_name $config::bram_addr_width
 connect_cell $avg_name {
   clk         $adc_clk
   restart     $address_name/restart
-  avg_on      [cfg_pin avg0]
-  period      [cfg_pin avg_period0]
-  threshold   [cfg_pin avg_threshold0]
-  n_avg_min   [cfg_pin n_avg_min0]
+  avg_on      [cfg_pin avg]
+  period      [cfg_pin avg_period]
+  threshold   [cfg_pin avg_threshold]
+  n_avg_min   [cfg_pin n_avg_min]
   addr        $recorder_name/addr
   dout        $recorder_name/adc
   wen         $recorder_name/wen
   n_avg       [sts_pin n_avg]
   ready       [sts_pin avg_ready]
-  avg_on_out  [sts_pin avg_on_out0]
+  avg_on_out  [sts_pin avg_on_out]
 }
 
 connect_cell $subtract_name {

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -2,6 +2,8 @@ set -e
 
 pip install -r requirements.txt
 
+python scripts/make.py --tests
+
 for instrument in oscillo spectrum pid
 do
     make NAME=$instrument server

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -2,7 +2,7 @@ set -e
 
 pip install -r requirements.txt
 
-python scripts/make.py --tests
+python scripts/make.py --test
 
 for instrument in oscillo spectrum pid
 do

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -58,25 +58,12 @@ def load_config(project):
     return config
 
 def parse_brackets(string):
-    """ ex: 'pwm', 4 = parse_brackets('pwm[4]') """
+    """ ex: 'pwm', '4' = parse_brackets('pwm[4]') """
     start, end = map(lambda char : string.find(char), ('[',']'))
     if start >= 0 and end >= 0:
-        return string[0:start], int(string[start+1:end])
+        return string[0:start], string[start+1:end]
     else:
-        return string, 1
-
-def parse_brackets_list(list_):
-    new_list = []
-    if list_ is None:
-        return None
-    for string in list_:
-        s, num = parse_brackets(string)
-        if num == 1:
-            new_list.append(s)
-        else:
-            for i in range(num):
-                new_list.append(s+str(i))
-    return new_list
+        return string, '1'
 
 def get_config(project):
     """ Get the config dictionary recursively. 
@@ -94,8 +81,22 @@ def get_config(project):
 
     # Config and status registers
     lists = ['config_registers','status_registers']
+    params = cfg['parameters']
     for list_ in lists:
-        cfg[list_] = parse_brackets_list(cfg[list_])
+        new_list = []
+        if cfg[list_] is not None:
+            for string in cfg[list_]:
+                s, num = parse_brackets(string)
+                if num.isdigit():
+                    num = int(num)
+                else:
+                    num = params[num]
+                if num == 1:
+                    new_list.append(s)
+                else:
+                    for i in range(num):
+                        new_list.append(s+str(i))
+        cfg[list_] = new_list
 
     # Modules
     for module in cfg['modules']:

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -57,6 +57,28 @@ def load_config(project):
         config = yaml.load(config_file)        
     return config
 
+def parse_brackets(string):
+    """ ex: 'pwm', 4 = parse_brackets('pwm[4]') """
+    start = string.find('[')
+    end = string.find(']')
+    if start >= 0 and end >= 0:
+        return string[0:start], int(string[start+1:end])
+    else:
+        return string, 1
+
+def parse_brackets_list(list_):
+    new_list = []
+    if list_ is None:
+        return None
+    for string in list_:
+        s, num = parse_brackets(string)
+        if num == 1:
+            new_list.append(s)
+        else:
+            for i in range(num):
+                new_list.append(s+str(i))
+    return new_list
+
 def get_config(project):
     """ Get the config dictionary recursively. 
     ex: config = get_config('oscillo')
@@ -69,6 +91,10 @@ def get_config(project):
     props = ['board','host']
     for prop in props:
         cfg[prop] = get_prop(project, prop)
+
+    lists = ['config_registers','status_registers']
+    for list_ in lists:
+        cfg[list_] = parse_brackets_list(cfg[list_])
 
     # Modules
     for module in cfg['modules']:

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -90,6 +90,7 @@ def get_config(project):
                 if num.isdigit():
                     num = int(num)
                 else:
+                    assert(num in params)
                     num = params[num]
                 if num == 1:
                     new_list.append(s)

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -59,8 +59,7 @@ def load_config(project):
 
 def parse_brackets(string):
     """ ex: 'pwm', 4 = parse_brackets('pwm[4]') """
-    start = string.find('[')
-    end = string.find(']')
+    start, end = map(lambda char : string.find(char), ('[',']'))
     if start >= 0 and end >= 0:
         return string[0:start], int(string[start+1:end])
     else:
@@ -84,6 +83,7 @@ def get_config(project):
     ex: config = get_config('oscillo')
     """
     cfg = load_config(project)
+
     # Get missing elements from ancestors
     lists = ['cores','xdc','modules']
     for list_ in lists:
@@ -92,6 +92,7 @@ def get_config(project):
     for prop in props:
         cfg[prop] = get_prop(project, prop)
 
+    # Config and status registers
     lists = ['config_registers','status_registers']
     for list_ in lists:
         cfg[list_] = parse_brackets_list(cfg[list_])


### PR DESCRIPTION
Add possibility to use array notation in `main.yml` :

```yml
config_registers:
  - spi_in
  - led
  - pwm[n_pwm]
  - addr
  - avg[n_adc]
  - dac_period[n_dac]
  - avg_period
  - avg_threshold
  - n_avg_min[n_adc]
  - dac_select
  - addr_select
  - clken_mask

status_registers:
  - spi_out
  - n_avg[n_adc]
  - avg_ready[n_adc]
  - avg_on_out[n_adc]
  - counter[2]

parameters:
  bram_addr_width: 13
  dac_width: 14
  adc_width: 14
  pwm_width: 10
  n_pwm: 4
  n_dac_bram: 3
  n_dac: 2
  n_adc: 2
```